### PR TITLE
Bump CI Python to 3.12 and update action versions

### DIFF
--- a/.github/workflows/pypi_upload.yaml
+++ b/.github/workflows/pypi_upload.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: false
           submodules: false
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
       - name: Setup Pip Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: false
           submodules: false
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
       - name: Setup Pip Cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v2 to v4
- Upgrade `actions/setup-python` from v1 to v5
- Bump Python version from 3.9 to 3.12 (3.9 is no longer available on GitHub-hosted runners)

Fixes #16

## Test plan
- [ ] CI build passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)